### PR TITLE
Update DeepgramPipeline Message Filtering for WhisperKit Compatibility via Argmax Local Server

### DIFF
--- a/src/sdbench/pipeline/streaming_transcription/deepgram.py
+++ b/src/sdbench/pipeline/streaming_transcription/deepgram.py
@@ -117,19 +117,26 @@ class DeepgramApi:
                         # There is no transcript in it.
                         continue
                     if msg["channel"]["alternatives"][0]["transcript"] != "":
-                        audio_cursor_l.append(audio_cursor)
-                        model_timestamps_hypothesis.append(msg["channel"]["alternatives"][0]["words"])
-                        interim_transcripts.append(transcript + "" + msg["channel"]["alternatives"][0]["transcript"])
-                        logger.debug(
-                            "\n"
-                            + "Transcription: "
-                            + transcript
-                            + ""
-                            + msg["channel"]["alternatives"][0]["transcript"]
-                        )
-                        if msg["is_final"]:
+                        if not msg["is_final"]:
+                            audio_cursor_l.append(audio_cursor)
+                            model_timestamps_hypothesis.append(msg["channel"]["alternatives"][0]["words"])
+                            interim_transcripts.append(transcript + " " + msg["channel"]["alternatives"][0]["transcript"])
+                            logger.debug(
+                                "\n"
+                                + "Transcription: "
+                                + transcript
+                                + msg["channel"]["alternatives"][0]["transcript"]
+                            )
+
+                        elif msg["is_final"] and (not msg["from_finalize"]):
                             confirmed_audio_cursor_l.append(audio_cursor)
                             transcript = transcript + " " + msg["channel"]["alternatives"][0]["transcript"]
+                            confirmed_interim_transcripts.append(transcript)
+                            model_timestamps_confirmed.append(msg["channel"]["alternatives"][0]["words"])
+  
+                        elif msg["is_final"] and msg["from_finalize"]:
+                            confirmed_audio_cursor_l.append(audio_cursor)
+                            transcript = msg["channel"]["alternatives"][0]["transcript"]
                             confirmed_interim_transcripts.append(transcript)
                             model_timestamps_confirmed.append(msg["channel"]["alternatives"][0]["words"])
 


### PR DESCRIPTION
This PR modifies the message filtering logic in the `DeepgramPipeline` to support `WhisperKit's` partial hypothesis behavior, using the Argmax local server.

Unlike `Deepgram`, which only emits new hypotheses after confirming previous ones, `WhisperKit `can emit partial confirmations while continuing to make hypotheses. To accommodate this, the filtering logic has been updated to correctly track interim results.

**Key Changes:**

- Adds support for partial confirmation handling in `WhisperKit` using argmax local server via DeepgramPipeline.

- Maintains existing behavior for Deepgram—no impact on real-time transcription results.

- Resolves inflated number correction metric previously seen with WhisperKit.

These changes ensure compatibility with WhisperKit while preserving the Deepgram pipeline behavior.