### PR TITLE
Unify benchmarks from whisperkittools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ wandb_data/
 
 # Inference outputs
 inference_outputs/
+
+# Miscellaneous
+miscellaneous/

--- a/src/sdbench/dataset/dataset_aliases.py
+++ b/src/sdbench/dataset/dataset_aliases.py
@@ -11,7 +11,7 @@ from .dataset_registry import DatasetRegistry
 def register_dataset_aliases() -> None:
     """Register all dataset aliases with their configurations."""
 
-    # Diarization and Orchestration datasets
+    ########## DIARIZATION ##########
     DatasetRegistry.register_alias(
         "voxconverse",
         DatasetConfig(dataset_id="diarizers-community/voxconverse", split="test"),
@@ -87,27 +87,6 @@ def register_dataset_aliases() -> None:
     )
 
     DatasetRegistry.register_alias(
-        "timit",
-        DatasetConfig(dataset_id="kylelovesllms/timit_asr", split="test", num_samples=300),
-        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
-        description="TIMIT dataset for streaming transcription evaluation",
-    )
-
-    DatasetRegistry.register_alias(
-        "timit-debug",
-        DatasetConfig(dataset_id="kylelovesllms/timit_asr", split="test", num_samples=5),
-        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
-        description="TIMIT dataset for streaming transcription evaluation for debugging purposes only",
-    )
-
-    DatasetRegistry.register_alias(
-        "timit-stitched",
-        DatasetConfig(dataset_id="argmaxinc/timit_stitched", split="test"),
-        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
-        description="TIMIT stitched dataset for streaming transcription evaluation",
-    )
-
-    DatasetRegistry.register_alias(
         "icsi",
         DatasetConfig(dataset_id="argmaxinc/icsi", split="test"),
         supported_pipeline_types={
@@ -132,6 +111,310 @@ def register_dataset_aliases() -> None:
             PipelineType.DIARIZATION,
         },
         description="AliMeetings dataset for speaker diarization",
+    )
+
+    ########## TRANSCRIPTION ##########
+
+    DatasetRegistry.register_alias(
+        "librispeech",
+        DatasetConfig(dataset_id="argmaxinc/librispeech-openbench", split="test", subset="full"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="LibriSpeech dataset for transcription evaluation",
+    )
+
+    DatasetRegistry.register_alias(
+        "librispeech-200",
+        DatasetConfig(dataset_id="argmaxinc/librispeech-openbench", split="test", subset="200"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="LibriSpeech dataset for transcription evaluation with only 200 files. Commonly used for debugging or get an estimate of the performance of the model.",
+    )
+
+    DatasetRegistry.register_alias(
+        "earnings22",
+        DatasetConfig(dataset_id="argmaxinc/earnings22-openbench", split="test", subset="full"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Earnings call dataset for transcription evaluation.",
+    )
+
+    DatasetRegistry.register_alias(
+        "earnings22-12hours",
+        DatasetConfig(dataset_id="argmaxinc/earnings22-openbench", split="test", subset="12hours"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Earnings call dataset for transcription evaluation with only 12 hours of audio.",
+    )
+
+    DatasetRegistry.register_alias(
+        "earnings22-3hours",
+        DatasetConfig(dataset_id="argmaxinc/earnings22-openbench", split="test", subset="3hours"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Earnings call dataset for transcription evaluation with only 3 hours of audio.",
+    )
+
+    DatasetRegistry.register_alias(
+        "common-voice",
+        DatasetConfig(
+            dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="full"
+        ),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains all languages",
+    )
+
+    DatasetRegistry.register_alias(
+        "common-voice",
+        DatasetConfig(
+            dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="full"
+        ),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains all languages",
+    )
+
+    # Common Voice specific languages subsets
+
+    # English
+    DatasetRegistry.register_alias(
+        "common-voice-en",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="en"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only english",
+    )
+
+    # Spanish
+    DatasetRegistry.register_alias(
+        "common-voice-es",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="es"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only spanish",
+    )
+
+    # German
+    DatasetRegistry.register_alias(
+        "common-voice-de",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="de"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only german",
+    )
+
+    # French
+    DatasetRegistry.register_alias(
+        "common-voice-fr",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="fr"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only french",
+    )
+
+    # Portuguese
+    DatasetRegistry.register_alias(
+        "common-voice-pt",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="pt"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only portuguese",
+    )
+
+    # Japanese
+    DatasetRegistry.register_alias(
+        "common-voice-ja",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="ja"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only japanese",
+    )
+
+    # Italian
+    DatasetRegistry.register_alias(
+        "common-voice-it",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="it"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only italian",
+    )
+
+    # Chinese
+    DatasetRegistry.register_alias(
+        "common-voice-zh",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="zh"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only chinese",
+    )
+
+    # Dutch
+    DatasetRegistry.register_alias(
+        "common-voice-nl",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="nl"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only dutch",
+    )
+
+    # Polish
+    DatasetRegistry.register_alias(
+        "common-voice-pl",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="pl"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only polish",
+    )
+
+    # Indonesian
+    DatasetRegistry.register_alias(
+        "common-voice-id",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="id"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only indonesian",
+    )
+
+    # Galician
+    DatasetRegistry.register_alias(
+        "common-voice-gl",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="gl"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only galician",
+    )
+
+    # Romanian
+    DatasetRegistry.register_alias(
+        "common-voice-ro",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="ro"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only romanian",
+    )
+
+    # Czech
+    DatasetRegistry.register_alias(
+        "common-voice-cs",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="cs"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only czech",
+    )
+
+    # Swedish
+    DatasetRegistry.register_alias(
+        "common-voice-sv",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="sv"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only swedish",
+    )
+
+    # Hungarian
+    DatasetRegistry.register_alias(
+        "common-voice-hu",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="hu"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only hungarian",
+    )
+
+    # Greek
+    DatasetRegistry.register_alias(
+        "common-voice-el",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="el"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only greek",
+    )
+
+    # Finnish
+    DatasetRegistry.register_alias(
+        "common-voice-fi",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="fi"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only finnish",
+    )
+
+    # Vietnamese
+    DatasetRegistry.register_alias(
+        "common-voice-vi",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="vi"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only vietnamese",
+    )
+
+    # Danish
+    DatasetRegistry.register_alias(
+        "common-voice-da",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="da"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only danish",
+    )
+
+    # Catalan
+    DatasetRegistry.register_alias(
+        "common-voice-ca",
+        DatasetConfig(dataset_id="argmaxinc/common_voice_17_0-argmax_subset-400-openbench", split="test", subset="ca"),
+        supported_pipeline_types={
+            PipelineType.TRANSCRIPTION,
+        },
+        description="Common Voice dataset for transcription evaluation with up to 400 samples per language this subset contains only catalan",
+    )
+
+    ########## STREAMING TRANSCRIPTION ##########
+
+    DatasetRegistry.register_alias(
+        "timit",
+        DatasetConfig(dataset_id="kylelovesllms/timit_asr", split="test", num_samples=300),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT dataset for streaming transcription evaluation",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-debug",
+        DatasetConfig(dataset_id="kylelovesllms/timit_asr", split="test", num_samples=5),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT dataset for streaming transcription evaluation for debugging purposes only",
+    )
+
+    DatasetRegistry.register_alias(
+        "timit-stitched",
+        DatasetConfig(dataset_id="argmaxinc/timit_stitched", split="test"),
+        supported_pipeline_types={PipelineType.STREAMING_TRANSCRIPTION},
+        description="TIMIT stitched dataset for streaming transcription evaluation",
     )
 
 

--- a/src/sdbench/dataset/dataset_base.py
+++ b/src/sdbench/dataset/dataset_base.py
@@ -34,6 +34,7 @@ class DatasetConfig(BaseModel):
     )
 
     def load(self) -> HfDataset:
+        # TODO: Add support for streaming datasets
         ds = load_dataset(self.dataset_id, self.subset, split=self.split)
         if self.num_samples is not None:
             ds = ds.take(self.num_samples)
@@ -67,6 +68,7 @@ class BaseSample(BaseModel, Generic[ReferenceType, ExtraInfoType]):
         arbitrary_types_allowed = True
 
 
+# TODO: Add support for datasets from local files
 class BaseDataset(ABC, Generic[SampleType]):
     """Base class for all dataset types with common functionality."""
 

--- a/src/sdbench/pipeline/pipeline_aliases.py
+++ b/src/sdbench/pipeline/pipeline_aliases.py
@@ -22,6 +22,10 @@ from .streaming_transcription import (
     GladiaStreamingPipeline,
     OpenAIStreamingPipeline,
 )
+from .transcription import (
+    SpeechAnalyzerPipeline,
+    WhisperKitPipeline,
+)
 
 
 def register_pipeline_aliases() -> None:
@@ -101,6 +105,50 @@ def register_pipeline_aliases() -> None:
             "threads": 8,
         },
         description="WhisperX diarized transcription pipeline from https://github.com/m-bain/whisperX",
+    )
+
+    ################# TRANSCRIPTION PIPELINES #################
+
+    PipelineRegistry.register_alias(
+        "whisperkit-tiny",
+        WhisperKitPipeline,
+        default_config={
+            "model_version": "tiny",
+            "word_timestamps": True,
+            "chunking_strategy": "vad",
+        },
+        description="WhisperKit transcription pipeline (open-source version) using the tiny version of the model. Requires Swift and Xcode installed.",
+    )
+
+    PipelineRegistry.register_alias(
+        "whisperkit-large-v3",
+        WhisperKitPipeline,
+        default_config={
+            "model_version": "large-v3",
+            "word_timestamps": True,
+            "chunking_strategy": "vad",
+        },
+        description="WhisperKit transcription pipeline (open-source version) using the large-v3 version of the model. Requires Swift and Xcode installed.",
+    )
+
+    PipelineRegistry.register_alias(
+        "whisperkit-large-v3-turbo",
+        WhisperKitPipeline,
+        default_config={
+            "model_version": "large-v3-v20240930",
+            "word_timestamps": True,
+            "chunking_strategy": "vad",
+        },
+        description="WhisperKit transcription pipeline (open-source version) using the large-v3-v20240930 version of the model (which is the same as large-v3-turbo from OpenAI). Requires Swift and Xcode installed.",
+    )
+
+    PipelineRegistry.register_alias(
+        "speech-analyzer",
+        SpeechAnalyzerPipeline,
+        default_config={
+            "clone_dir": "./speech_analyzer_repo",
+        },
+        description="Speech Analyzer transcription pipeline (open-source version). Requires Swift and Xcode installed.",
     )
 
     ################# STREAMING TRANSCRIPTION PIPELINES #################

--- a/src/sdbench/pipeline/streaming_transcription/deepgram.py
+++ b/src/sdbench/pipeline/streaming_transcription/deepgram.py
@@ -120,12 +120,11 @@ class DeepgramApi:
                         if not msg["is_final"]:
                             audio_cursor_l.append(audio_cursor)
                             model_timestamps_hypothesis.append(msg["channel"]["alternatives"][0]["words"])
-                            interim_transcripts.append(transcript + " " + msg["channel"]["alternatives"][0]["transcript"])
+                            interim_transcripts.append(
+                                transcript + " " + msg["channel"]["alternatives"][0]["transcript"]
+                            )
                             logger.debug(
-                                "\n"
-                                + "Transcription: "
-                                + transcript
-                                + msg["channel"]["alternatives"][0]["transcript"]
+                                "\n" + "Transcription: " + transcript + msg["channel"]["alternatives"][0]["transcript"]
                             )
 
                         elif msg["is_final"] and (not msg["from_finalize"]):
@@ -133,7 +132,7 @@ class DeepgramApi:
                             transcript = transcript + " " + msg["channel"]["alternatives"][0]["transcript"]
                             confirmed_interim_transcripts.append(transcript)
                             model_timestamps_confirmed.append(msg["channel"]["alternatives"][0]["words"])
-  
+
                         elif msg["is_final"] and msg["from_finalize"]:
                             confirmed_audio_cursor_l.append(audio_cursor)
                             transcript = msg["channel"]["alternatives"][0]["transcript"]

--- a/src/sdbench/pipeline/transcription/__init__.py
+++ b/src/sdbench/pipeline/transcription/__init__.py
@@ -2,3 +2,14 @@
 # Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
 
 from .common import TranscriptionOutput
+from .speech_analyzer import SpeechAnalyzerConfig, SpeechAnalyzerPipeline
+from .whisperkit import WhisperKitPipeline, WhisperKitPipelineConfig
+
+
+__all__ = [
+    "TranscriptionOutput",
+    "SpeechAnalyzerPipeline",
+    "SpeechAnalyzerConfig",
+    "WhisperKitPipeline",
+    "WhisperKitPipelineConfig",
+]

--- a/src/sdbench/pipeline/transcription/common.py
+++ b/src/sdbench/pipeline/transcription/common.py
@@ -1,8 +1,17 @@
 # For licensing see accompanying LICENSE.md file.
 # Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
 
+from pydantic import Field
+
 from ...pipeline_prediction import Transcript
-from ..base import PipelineOutput
+from ..base import PipelineConfig, PipelineOutput
+
+
+# TODO: Add support for forced language transcription
+class TranscriptionConfig(PipelineConfig):
+    force_language: bool = Field(
+        False, description="Force the language of the audio files i.e. hint the model to use the correct language."
+    )
 
 
 class TranscriptionOutput(PipelineOutput[Transcript]):

--- a/src/sdbench/pipeline/transcription/speech_analyzer.py
+++ b/src/sdbench/pipeline/transcription/speech_analyzer.py
@@ -1,0 +1,134 @@
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from argmaxtools.utils import _maybe_git_clone, get_logger
+from pydantic import BaseModel, Field
+
+from ...dataset import TranscriptionSample
+from ...pipeline_prediction import Transcript
+from ..base import Pipeline, PipelineType, register_pipeline
+from .common import TranscriptionConfig, TranscriptionOutput
+
+
+logger = get_logger(__name__)
+
+SPEECH_ANALYZER_REPO_URL = "https://github.com/argmaxinc/apple-speechanalyzer-cli-example"
+PRODUCT_NAME = "apple-speechanalyzer-cli"
+TEMP_AUDIO_DIR = Path("./temp_audio")
+SPEECH_ANALYZER_DEFAULT_REPORT_PATH = Path("speech_analyzer_report")
+SPEECH_ANALYZER_DEFAULT_CLONE_DIR = "./speech_analyzer_repo"
+
+
+class SpeechAnalyzerConfig(TranscriptionConfig):
+    clone_dir: str = Field(
+        default=SPEECH_ANALYZER_DEFAULT_CLONE_DIR, description="The directory to clone the Speech Analyzer repo into"
+    )
+    commit_hash: str | None = Field(
+        default=None, description="The commit hash of the Speech Analyzer repo when cloning"
+    )
+
+
+class SpeechAnalyzerCliInput(BaseModel):
+    audio_path: Path
+    keep_audio: bool = False
+    language: str | None = None
+
+
+class SpeechAnalyzerCli:
+    def __init__(self, config: SpeechAnalyzerConfig) -> None:
+        self.config = config
+        self.cli_path = self._clone_and_build_cli()
+
+    def _build_cli(self, repo_dir: str) -> str:
+        build_cmd = f"swift build -c release --product {PRODUCT_NAME}"
+        try:
+            subprocess.run(build_cmd, cwd=repo_dir, check=True, shell=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Failed to build Speech Analyzer CLI with command: {build_cmd}\n"
+                f"Exit code: {e.returncode}\n"
+                f"Output: {e.output}\n"
+                f"Stdout: {getattr(e, 'stdout', None)}\n"
+                f"Stderr: {getattr(e, 'stderr', None)}"
+            ) from e
+
+        # Get the path to the built CLI
+        try:
+            result = subprocess.run(
+                f"{build_cmd} --show-bin-path",
+                cwd=repo_dir,
+                stdout=subprocess.PIPE,
+                shell=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Failed to get Speech Analyzer CLI binary path with command: {build_cmd} --show-bin-path\n"
+                f"Exit code: {e.returncode}\n"
+                f"Output: {e.output}\n"
+                f"Stdout: {getattr(e, 'stdout', None)}\n"
+                f"Stderr: {getattr(e, 'stderr', None)}"
+            ) from e
+        return result.stdout.strip()
+
+    def _clone_and_build_cli(self) -> None:
+        repo_name = SPEECH_ANALYZER_REPO_URL.split("/")[-1]
+        repo_owner = SPEECH_ANALYZER_REPO_URL.split("/")[-2]
+        repo_dir, commit_hash = _maybe_git_clone(
+            out_dir=self.config.clone_dir,
+            hub_url="github.com",
+            repo_name=repo_name,
+            repo_owner=repo_owner,
+            commit_hash=self.config.commit_hash,
+        )
+        self.config.commit_hash = commit_hash
+
+        return self._build_cli(repo_dir)
+
+    def transcribe(self, input: SpeechAnalyzerCliInput) -> Path:
+        SPEECH_ANALYZER_DEFAULT_REPORT_PATH.mkdir(parents=True, exist_ok=True)
+        output_path = SPEECH_ANALYZER_DEFAULT_REPORT_PATH / input.audio_path.with_suffix(".txt").name
+
+        cmd = [
+            self.cli_path,
+            "--input-audio-path",
+            str(input.audio_path),
+            "--output-text-path",
+            str(output_path),
+        ]
+        if input.language:
+            cmd.extend(["--locale", input.language])
+
+        subprocess.run(cmd, cwd=self.config.clone_dir, check=True)
+
+        if not input.keep_audio:
+            input.audio_path.unlink(missing_ok=True)
+
+        return output_path
+
+
+@register_pipeline
+class SpeechAnalyzerPipeline(Pipeline):
+    _config_class = SpeechAnalyzerConfig
+    pipeline_type = PipelineType.TRANSCRIPTION
+
+    def build_pipeline(self) -> Callable[[SpeechAnalyzerCliInput], Path]:
+        engine = SpeechAnalyzerCli(config=self.config)
+        return engine.transcribe
+
+    def parse_input(self, input_sample: TranscriptionSample) -> SpeechAnalyzerCliInput:
+        return SpeechAnalyzerCliInput(
+            audio_path=input_sample.save_audio(TEMP_AUDIO_DIR),
+            keep_audio=False,
+        )
+
+    def parse_output(self, output: Path) -> TranscriptionOutput:
+        transcription = output.read_text()
+        return TranscriptionOutput(
+            prediction=Transcript.from_words_info(words=transcription.split()),
+        )

--- a/src/sdbench/pipeline/transcription/whisperkit.py
+++ b/src/sdbench/pipeline/transcription/whisperkit.py
@@ -1,0 +1,278 @@
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2025 Argmax, Inc. All Rights Reserved.
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from argmaxtools.utils import _maybe_git_clone, get_logger
+from pydantic import BaseModel, Field
+
+from ...dataset import TranscriptionSample
+from ...pipeline_prediction import Transcript
+from ..base import Pipeline, PipelineType, register_pipeline
+from .common import TranscriptionConfig, TranscriptionOutput
+
+
+logger = get_logger(__name__)
+
+# Constants
+WHISPERKIT_REPO_URL = "https://github.com/argmaxinc/WhisperKit"
+PRODUCT_NAME = "whisperkit-cli"
+TEMP_AUDIO_DIR = Path("./temp_audio")
+WHISPERKIT_DEFAULT_REPORT_PATH = "./whisperkit_report"
+
+
+class WhisperKitPipelineConfig(TranscriptionConfig):
+    """Configuration for WhisperKit transcription operations."""
+
+    model_version: str = Field(
+        default="base",
+        description="The version of the WhisperKit model to use (e.g., 'tiny', 'base', 'small', 'large-v3')",
+    )
+    word_timestamps: bool = Field(
+        default=True,
+        description="Whether to include word timestamps in the output",
+    )
+    chunking_strategy: str | None = Field(
+        default="vad",
+        description="The chunking strategy to use either `none` or `vad`",
+    )
+    report_path: str | None = Field(
+        default=WHISPERKIT_DEFAULT_REPORT_PATH,
+        description="The path to the directory where the report files will be saved. If not provided, the report files will be saved in the current working directory.",
+    )
+    prompt: str | None = Field(
+        default=None,
+        description="Initial prompt for transcription",
+    )
+    text_decoder_compute_units: str = Field(
+        default="cpuAndNeuralEngine",
+        description="Compute units for text decoder",
+    )
+    audio_encoder_compute_units: str = Field(
+        default="cpuAndNeuralEngine",
+        description="Compute units for audio encoder",
+    )
+
+    def create_report_path(self) -> Path:
+        if self.report_path is None:
+            return Path.cwd()
+
+        report_dir = Path(self.report_path)
+
+        if report_dir.exists():
+            logger.info(f"Report dir already exists for WhisperKit at: {report_dir}")
+            return report_dir
+
+        report_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created report dir for WhisperKit at: {report_dir}")
+        return report_dir
+
+    def generate_cli_args(self) -> list[str]:
+        args = [
+            "--model",
+            self.model_version,
+            "--report",  # Always generate the report files
+        ]
+
+        if self.chunking_strategy:
+            args.extend(["--chunking-strategy", self.chunking_strategy])
+        if self.word_timestamps:
+            args.append("--word-timestamps")
+        if self.report_path:
+            args.extend(["--report-path", self.report_path])
+        if self.prompt:
+            args.extend(["--prompt", f'"{self.prompt}"'])
+        if self.text_decoder_compute_units:
+            args.extend(["--text-decoder-compute-units", self.text_decoder_compute_units])
+        if self.audio_encoder_compute_units:
+            args.extend(["--audio-encoder-compute-units", self.audio_encoder_compute_units])
+
+        logger.info(f"Generating CLI args for WhisperKit: {args}")
+        return args
+
+
+class WhisperKitEngineConfig(BaseModel):
+    """Base configuration for WhisperKit operations."""
+
+    commit_hash: str | None = Field(
+        default=None,
+        description="The commit hash of the WhisperKit repo when cloning",
+    )
+    cli_path: str | None = Field(
+        default=None,
+        description="The path to the WhisperKit CLI",
+    )
+    clone_dir: str = Field(
+        default="./whisperkit_repo",
+        description="Directory to clone and build the CLI",
+    )
+
+
+class TranscriptionCliInput(BaseModel):
+    """Input for transcription CLI."""
+
+    audio_path: Path
+    keep_audio: bool = False
+    language: str | None = None
+
+
+class TranscriptionCliOutput(BaseModel):
+    """Output for transcription CLI."""
+
+    json_report_path: Path = Field(
+        ...,
+        description="Path to the JSON report with transcription results",
+    )
+    srt_report_path: Path = Field(
+        ...,
+        description="Path to the .srt file containing transcription results",
+    )
+
+
+class WhisperKitEngine:
+    """Unified CLI interface for WhisperKit operations."""
+
+    def __init__(
+        self,
+        config: WhisperKitEngineConfig,
+        transcription_config: WhisperKitPipelineConfig,
+    ):
+        self.config = config
+        self.cli_path = config.cli_path or self._clone_and_build_cli()
+        self.transcription_config = transcription_config
+        self.transcription_args = self.transcription_config.generate_cli_args()
+        self.transcription_config.create_report_path()
+
+    def _clone_and_build_cli(self) -> str:
+        """Clone the repository and build the CLI."""
+        os.makedirs(self.config.clone_dir, exist_ok=True)
+        if not WHISPERKIT_REPO_URL:
+            raise ValueError("Repository URL is not set")
+
+        logger.info(f"Cloning repo {WHISPERKIT_REPO_URL} into {self.config.clone_dir}")
+        repo_name = WHISPERKIT_REPO_URL.split("/")[-1]
+        repo_owner = WHISPERKIT_REPO_URL.split("/")[-2]
+
+        repo_dir, commit_hash = _maybe_git_clone(
+            out_dir=self.config.clone_dir,
+            hub_url="github.com",
+            repo_name=repo_name,
+            repo_owner=repo_owner,
+            commit_hash=self.config.commit_hash,
+        )
+        logger.info(f"{repo_name} -> Commit hash: {commit_hash}")
+
+        try:
+            build_dir = self._build_cli(repo_dir)
+            cli_path = os.path.join(build_dir, PRODUCT_NAME)
+            self.config.commit_hash = commit_hash
+            return cli_path
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Build failed with return code {e.returncode}")
+            logger.error(f"Build stdout:\n{e.stdout}")
+            logger.error(f"Build stderr:\n{e.stderr}")
+            raise RuntimeError(
+                f"Failed to build CLI: Exit code {e.returncode}\nStdout: {e.stdout}\nStderr: {e.stderr}"
+            )
+
+    def _build_cli(self, repo_dir: str) -> str:
+        """Build the CLI and return the build directory path."""
+        logger.info(f"Building {PRODUCT_NAME} CLI...")
+
+        build_cmd = f"swift build -c release --product {PRODUCT_NAME}"
+
+        subprocess.run(
+            build_cmd,
+            cwd=repo_dir,
+            shell=True,
+            check=True,
+        )
+        logger.info(f"Successfully built {PRODUCT_NAME} CLI!")
+
+        result = subprocess.run(
+            f"{build_cmd} --show-bin-path",
+            cwd=repo_dir,
+            stdout=subprocess.PIPE,
+            shell=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def transcribe(self, input: TranscriptionCliInput) -> TranscriptionCliOutput:
+        """Run transcription on the given audio file."""
+        cmd = [
+            self.cli_path,
+            "transcribe",
+            "--audio-path",
+            str(input.audio_path),
+            *self.transcription_args,
+        ]
+        if input.language:
+            cmd.extend(["--language", input.language])
+
+        logger.debug(f"Running WhisperKit CLI: {cmd}")
+
+        report_dir = self.transcription_config.create_report_path()
+        if not report_dir:
+            raise ValueError("Report directory not configured")
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"CLI command failed: {e.stderr}")
+
+        if not input.keep_audio:
+            input.audio_path.unlink(missing_ok=True)
+
+        json_report_path = report_dir / input.audio_path.with_suffix(".json").name
+        srt_report_path = report_dir / input.audio_path.with_suffix(".srt").name
+
+        return TranscriptionCliOutput(
+            json_report_path=json_report_path,
+            srt_report_path=srt_report_path,
+        )
+
+
+@register_pipeline
+class WhisperKitPipeline(Pipeline):
+    _config_class = WhisperKitPipelineConfig
+    pipeline_type = PipelineType.TRANSCRIPTION
+
+    def build_pipeline(self) -> Callable[[TranscriptionCliInput], TranscriptionCliOutput]:
+        # Create WhisperKit engine
+        engine_config = WhisperKitEngineConfig(
+            clone_dir="./whisperkit_repo",
+        )
+
+        engine = WhisperKitEngine(
+            config=engine_config,
+            transcription_config=self.config,
+        )
+
+        return engine.transcribe
+
+    def parse_input(self, input_sample: TranscriptionSample) -> TranscriptionCliInput:
+        return TranscriptionCliInput(
+            audio_path=input_sample.save_audio(TEMP_AUDIO_DIR),
+            keep_audio=False,
+        )
+
+    def parse_output(self, output: TranscriptionCliOutput) -> TranscriptionOutput:
+        """Parse JSON output file into TranscriptionOutput."""
+        with output.json_report_path.open("r") as f:
+            data = json.load(f)
+
+        transcript = Transcript.from_words_info(
+            words=[word["word"] for segment in data["segments"] for word in segment["words"]],
+            start=[word["start"] for segment in data["segments"] for word in segment["words"] if "start" in word],
+            end=[word["end"] for segment in data["segments"] for word in segment["words"] if "end" in word],
+        )
+
+        return TranscriptionOutput(
+            prediction=transcript,
+        )

--- a/src/sdbench/pipeline_prediction.py
+++ b/src/sdbench/pipeline_prediction.py
@@ -87,9 +87,9 @@ class Transcript(BaseModel):
     def from_words_info(
         cls,
         words: list[str],
-        start: list[float] | None,
-        end: list[float] | None,
-        speaker: list[str] | None,
+        start: list[float] | None = None,
+        end: list[float] | None = None,
+        speaker: list[str] | None = None,
     ) -> "Transcript":
         if start is None:
             start = [None] * len(words)


### PR DESCRIPTION
# What does this PR do?

This PR serves as the first step to unify the benchmarks once done in [whisperkittools](https://github.com/argmaxinc/whisperkittools/tree/main) to `SDBench` by adding some pipelines that were only in `whisperkittools`, and adding support for the main datasets used in `whisperkittools`

- Adds `WhisperKit` and Apple's `SpeechAnalyzer` as pipelines
- Adds useful aliases for new pipelines
- Add useful aliases for new datasets `common-voice`, `librispeech`, and `earnings22`